### PR TITLE
Update district_team_season_name_mapping.js

### DIFF
--- a/api/mongodb/collections/district_team_season_name_mapping.js
+++ b/api/mongodb/collections/district_team_season_name_mapping.js
@@ -1,414 +1,509 @@
 if (db.district_team_season_name_mapping.find().count() === 0) {
   db.district_team_season_name_mapping.insertMany([
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bessie Carmichael Juniors 2021-2022",
-      "teamSeasonName" : "Bessie Carmichael Juniors-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bessie Carmichael Select 2021-2022",
-      "teamSeasonName" : "Bessie Carmichael Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bret Harte Juniors 2021-2022",
-      "teamSeasonName" : "Bret Harte Juniors-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bret Harte Select 2021-2022",
-      "teamSeasonName" : "Bret Harte Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bryant Select 2021-2022",
-      "teamSeasonName" : "Bryant Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Cleveland Select 2021-2022",
-      "teamSeasonName" : "Cleveland Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "ER Taylor Juniors 2021-2022",
-      "teamSeasonName" : "ER Taylor Juniors-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "ER Taylor Select 2021-2022",
-      "teamSeasonName" : "ER Taylor Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Everett 2021-2022",
-      "teamSeasonName" : "Everett Middle School-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Francisco Middle School 2021-2022",
-      "teamSeasonName" : "Francisco Boys-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Hillcrest Juniors 2021-2022",
-      "teamSeasonName" : "Hillcrest Juniors-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Hillcrest Select 2021-2022",
-      "teamSeasonName" : "Bessie Carmichael Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "IHDC Select 2021-2022",
-      "teamSeasonName" : "IHDC Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "John Muir 2021-2022",
-      "teamSeasonName" : "John Muir-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Joseph Lee Rec Center 2021-2022",
-      "teamSeasonName" : "Joseph Lee Rec Center-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "MLK Coed 2021-2022",
-      "teamSeasonName" : "MLK Coed-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Paul Revere Juniors 2021-2022",
-      "teamSeasonName" : "Paul Revere Juniors-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Paul Revere Middle 2021-2022",
-      "teamSeasonName" : "Paul Revere Middle-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Paul Revere Select 2021-2022",
-      "teamSeasonName" : "Paul Revere Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Salvation Army KROC 2021-2022",
-      "teamSeasonName" : "Salvation Army KROC-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Sanchez Juniors 2021-2022",
-      "teamSeasonName" : "Sanchez Juniors-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Sanchez Select 2021-2022",
-      "teamSeasonName" : "Sanchez Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "TECA - Program Site Juniors 2021-2022",
-      "teamSeasonName" : "TECA Juniors"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "TECA - Program Site Select 2021-2022",
-      "teamSeasonName" : "TECA SELECT-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "TECA MS Boys 2021-2022",
-      "teamSeasonName" : "TECA MS Boys-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Up on Top 2021-2022",
-      "teamSeasonName" : "Up on Top - Program Site Select-2021 Fall"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bessie Carmichael Juniors 2021-2022",
-      "teamSeasonName" : "Bessie Carmichael Juniors-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bessie Carmichael Select 2021-2022",
-      "teamSeasonName" : "Bessie Carmichael Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bret Harte Juniors 2021-2022",
-      "teamSeasonName" : "Bret Harte Juniors-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bret Harte Select 2021-2022",
-      "teamSeasonName" : "Bret Harte Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Bryant Select 2021-2022",
-      "teamSeasonName" : "Bryant Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Cleveland Select 2021-2022",
-      "teamSeasonName" : "Cleveland Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "ER Taylor Juniors 2021-2022",
-      "teamSeasonName" : "ER Taylor Juniors-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "ER Taylor Select 2021-2022",
-      "teamSeasonName" : "ER Taylor Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Hillcrest Select 2021-2022",
-      "teamSeasonName" : "Hillcrest Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "IHDC Select 2021-2022",
-      "teamSeasonName" : "IHDC Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "John Muir 2021-2022",
-      "teamSeasonName" : "John Muir-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "MLK Coed 2021-2022",
-      "teamSeasonName" : "MLK Coed-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Paul Revere Juniors 2021-2022",
-      "teamSeasonName" : "Paul Revere Juniors-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Paul Revere Middle 2021-2022",
-      "teamSeasonName" : "Paul Revere Middle-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Paul Revere Select 2021-2022",
-      "teamSeasonName" : "Paul Revere Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Salvation Army KROC 2021-2022",
-      "teamSeasonName" : "Salvation Army KROC-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Sanchez Select 2021-2022",
-      "teamSeasonName" : "Sanchez Select-2022 Spring"
-    },
-    {
-      "district" : "district_1",
-      "districtSystemTeamName" : "Up on Top 2021-2022",
-      "teamSeasonName" : "Up on Top - Program Site Select-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Allendale",
-      "teamSeasonName" : "Allendale-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 ASCEND 3rd Grade",
-      "teamSeasonName" : "ASCEND Boys-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 ASCEND 3rd Grade",
-      "teamSeasonName" : "ASCEND Boys-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 ASCEND 4th Grade",
-      "teamSeasonName" : "ASCEND Girls-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 ASCEND 4th Grade",
-      "teamSeasonName" : "ASCEND Girls-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 CCPA",
-      "teamSeasonName" : "CCPA-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 CCPA",
-      "teamSeasonName" : "CCPA-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Elmhurst",
-      "teamSeasonName" : "Elmhurst-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Elmhurst",
-      "teamSeasonName" : "Elmhurst-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 EnCompass 4th Grade",
-      "teamSeasonName" : "EnCompass COED-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 EnCompass 4th Grade",
-      "teamSeasonName" : "EnCompass COED-2021 Fall2"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 EnCompass 4th Grade",
-      "teamSeasonName" : "EnCompass COED-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Esperanza",
-      "teamSeasonName" : "Esperanza COED-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Esperanza",
-      "teamSeasonName" : "Esperanza COED-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Global Family",
-      "teamSeasonName" : "Global Family Boys-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Global Family",
-      "teamSeasonName" : "Global Family Boys-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Greenleaf",
-      "teamSeasonName" : "Greenleaf-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Greenleaf",
-      "teamSeasonName" : "Greenleaf-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 ICS/TCN 3rd Grade",
-      "teamSeasonName" : "ICS/TCN 4th Grade-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 ICS/TCN 3rd Grade",
-      "teamSeasonName" : "ICS/TCN 4th Grade-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 ICS/TCN 3rd Grade",
-      "teamSeasonName" : "ICS/TCN 5th grade-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 ICS/TCN 3rd Grade",
-      "teamSeasonName" : "ICS/TCN 5th grade-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Learning Without Limits 3rd Grade",
-      "teamSeasonName" : "Learning Without Limits BOYS-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Learning Without Limits 3rd Grade",
-      "teamSeasonName" : "Learning Without Limits BOYS-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Learning Without Limits 4th Grade",
-      "teamSeasonName" : "ASCEND Girls-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Learning Without Limits 4th Grade",
-      "teamSeasonName" : "Learning Without Limits GIRLS-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Life Academy High School",
-      "teamSeasonName" : "Life Academy High School-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Life Academy High School",
-      "teamSeasonName" : "Life Academy High School-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Life Academy Middle School",
-      "teamSeasonName" : "Life Academy Middle School-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Life Academy Middle School",
-      "teamSeasonName" : "Life Academy Middle School-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Manzanita Community",
-      "teamSeasonName" : "Manzanita Community-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Manzanita Community",
-      "teamSeasonName" : "Manzanita SEED-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Manzanita SEED",
-      "teamSeasonName" : "2021-2022 Manzanita SEED"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Oakland Academy of Knowledge",
-      "teamSeasonName" : "Oakland Academy of Knowledge-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Sankofa",
-      "teamSeasonName" : "Sankofa United Select-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Sankofa",
-      "teamSeasonName" : "Sankofa United Juniors-2022 Spring"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Sankofa",
-      "teamSeasonName" : "Sankofa United Juniors-2021 Fall"
-    },
-    {
-      "district" : "district_2",
-      "districtSystemTeamName" : "2021-2022 Sankofa",
-      "teamSeasonName" : "Sankofa United Select-2021 Fall"
-    }
+  
+  {
+    "_id": "6248a534c90d5e4d20d1b9a9",
+    "district": "district_1",
+    "districtSystemTeamName": "Bessie Carmichael Juniors 2021-2022",
+    "teamSeasonName": "Bessie Carmichael Juniors-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9aa",
+    "district": "district_1",
+    "districtSystemTeamName": "Bessie Carmichael Select 2021-2022",
+    "teamSeasonName": "Bessie Carmichael Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ab",
+    "district": "district_1",
+    "districtSystemTeamName": "Bret Harte Juniors 2021-2022",
+    "teamSeasonName": "Bret Harte Juniors-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ac",
+    "district": "district_1",
+    "districtSystemTeamName": "Bret Harte Select 2021-2022",
+    "teamSeasonName": "Bret Harte Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ad",
+    "district": "district_1",
+    "districtSystemTeamName": "Bryant Select 2021-2022",
+    "teamSeasonName": "Bryant Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ae",
+    "district": "district_1",
+    "districtSystemTeamName": "Cleveland Select 2021-2022",
+    "teamSeasonName": "Cleveland Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9af",
+    "district": "district_1",
+    "districtSystemTeamName": "ER Taylor Juniors 2021-2022",
+    "teamSeasonName": "ER Taylor Juniors-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b0",
+    "district": "district_1",
+    "districtSystemTeamName": "ER Taylor Select 2021-2022",
+    "teamSeasonName": "ER Taylor Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b1",
+    "district": "district_1",
+    "districtSystemTeamName": "Everett 2021-2022",
+    "teamSeasonName": "Everett Middle School-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b2",
+    "district": "district_1",
+    "districtSystemTeamName": "Francisco Middle School 2021-2022",
+    "teamSeasonName": "Francisco Boys-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b3",
+    "district": "district_1",
+    "districtSystemTeamName": "Hillcrest Juniors 2021-2022",
+    "teamSeasonName": "Hillcrest Juniors-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b4",
+    "district": "district_1",
+    "districtSystemTeamName": "Hillcrest Select 2021-2022",
+    "teamSeasonName": "Bessie Carmichael Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b5",
+    "district": "district_1",
+    "districtSystemTeamName": "IHDC Select 2021-2022",
+    "teamSeasonName": "IHDC Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b6",
+    "district": "district_1",
+    "districtSystemTeamName": "John Muir 2021-2022",
+    "teamSeasonName": "John Muir-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b7",
+    "district": "district_1",
+    "districtSystemTeamName": "Joseph Lee Rec Center 2021-2022",
+    "teamSeasonName": "Joseph Lee Rec Center-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b8",
+    "district": "district_1",
+    "districtSystemTeamName": "MLK Coed 2021-2022",
+    "teamSeasonName": "MLK Coed-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9b9",
+    "district": "district_1",
+    "districtSystemTeamName": "Paul Revere Juniors 2021-2022",
+    "teamSeasonName": "Paul Revere Juniors-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ba",
+    "district": "district_1",
+    "districtSystemTeamName": "Paul Revere Middle 2021-2022",
+    "teamSeasonName": "Paul Revere Middle-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9bb",
+    "district": "district_1",
+    "districtSystemTeamName": "Paul Revere Select 2021-2022",
+    "teamSeasonName": "Paul Revere Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9bc",
+    "district": "district_1",
+    "districtSystemTeamName": "Salvation Army KROC 2021-2022",
+    "teamSeasonName": "Salvation Army KROC-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9bd",
+    "district": "district_1",
+    "districtSystemTeamName": "Sanchez Juniors 2021-2022",
+    "teamSeasonName": "Sanchez Juniors-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9be",
+    "district": "district_1",
+    "districtSystemTeamName": "Sanchez Select 2021-2022",
+    "teamSeasonName": "Sanchez Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9bf",
+    "district": "district_1",
+    "districtSystemTeamName": "TECA - Program Site Juniors 2021-2022",
+    "teamSeasonName": "TECA Juniors"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c0",
+    "district": "district_1",
+    "districtSystemTeamName": "TECA - Program Site Select 2021-2022",
+    "teamSeasonName": "TECA SELECT-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c1",
+    "district": "district_1",
+    "districtSystemTeamName": "TECA MS Boys 2021-2022",
+    "teamSeasonName": "TECA MS Boys-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c2",
+    "district": "district_1",
+    "districtSystemTeamName": "Up on Top 2021-2022",
+    "teamSeasonName": "Up on Top - Program Site Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c3",
+    "district": "district_1",
+    "districtSystemTeamName": "Bessie Carmichael Juniors 2021-2022",
+    "teamSeasonName": "Bessie Carmichael Juniors-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c4",
+    "district": "district_1",
+    "districtSystemTeamName": "Bessie Carmichael Select 2021-2022",
+    "teamSeasonName": "Bessie Carmichael Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c5",
+    "district": "district_1",
+    "districtSystemTeamName": "Bret Harte Juniors 2021-2022",
+    "teamSeasonName": "Bret Harte Juniors-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c6",
+    "district": "district_1",
+    "districtSystemTeamName": "Bret Harte Select 2021-2022",
+    "teamSeasonName": "Bret Harte Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c7",
+    "district": "district_1",
+    "districtSystemTeamName": "Bryant Select 2021-2022",
+    "teamSeasonName": "Bryant Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c8",
+    "district": "district_1",
+    "districtSystemTeamName": "Cleveland Select 2021-2022",
+    "teamSeasonName": "Cleveland Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9c9",
+    "district": "district_1",
+    "districtSystemTeamName": "ER Taylor Juniors 2021-2022",
+    "teamSeasonName": "ER Taylor Juniors-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ca",
+    "district": "district_1",
+    "districtSystemTeamName": "ER Taylor Select 2021-2022",
+    "teamSeasonName": "ER Taylor Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9cb",
+    "district": "district_1",
+    "districtSystemTeamName": "Hillcrest Select 2021-2022",
+    "teamSeasonName": "Hillcrest Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9cc",
+    "district": "district_1",
+    "districtSystemTeamName": "IHDC Select 2021-2022",
+    "teamSeasonName": "IHDC Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9cd",
+    "district": "district_1",
+    "districtSystemTeamName": "John Muir 2021-2022",
+    "teamSeasonName": "John Muir-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ce",
+    "district": "district_1",
+    "districtSystemTeamName": "MLK Coed 2021-2022",
+    "teamSeasonName": "MLK Coed-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9cf",
+    "district": "district_1",
+    "districtSystemTeamName": "Paul Revere Juniors 2021-2022",
+    "teamSeasonName": "Paul Revere Juniors-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d0",
+    "district": "district_1",
+    "districtSystemTeamName": "Paul Revere Middle 2021-2022",
+    "teamSeasonName": "Paul Revere Middle-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d1",
+    "district": "district_1",
+    "districtSystemTeamName": "Paul Revere Select 2021-2022",
+    "teamSeasonName": "Paul Revere Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d2",
+    "district": "district_1",
+    "districtSystemTeamName": "Salvation Army KROC 2021-2022",
+    "teamSeasonName": "Salvation Army KROC-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d3",
+    "district": "district_1",
+    "districtSystemTeamName": "Sanchez Select 2021-2022",
+    "teamSeasonName": "Sanchez Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d4",
+    "district": "district_1",
+    "districtSystemTeamName": "Up on Top 2021-2022",
+    "teamSeasonName": "Up on Top - Program Site Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d5",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Allendale",
+    "teamSeasonName": "Allendale-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d6",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 ASCEND 3rd Grade",
+    "teamSeasonName": "ASCEND Boys-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d7",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 ASCEND 3rd Grade",
+    "teamSeasonName": "ASCEND Boys-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d8",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 ASCEND 4th Grade",
+    "teamSeasonName": "ASCEND Girls-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9d9",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 ASCEND 4th Grade",
+    "teamSeasonName": "ASCEND Girls-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9da",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 CCPA",
+    "teamSeasonName": "CCPA-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9db",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 CCPA",
+    "teamSeasonName": "CCPA-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9dc",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Elmhurst",
+    "teamSeasonName": "Elmhurst-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9dd",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Elmhurst",
+    "teamSeasonName": "Elmhurst-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9de",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 EnCompass 4th Grade",
+    "teamSeasonName": "EnCompass COED-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e0",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 EnCompass 4th Grade",
+    "teamSeasonName": "EnCompass COED-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e1",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Esperanza",
+    "teamSeasonName": "Esperanza COED-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e2",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Esperanza",
+    "teamSeasonName": "Esperanza COED-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e3",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Global Family",
+    "teamSeasonName": "Global Family Boys-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e4",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Global Family",
+    "teamSeasonName": "Global Family Boys-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e5",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Greenleaf",
+    "teamSeasonName": "Greenleaf-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e6",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Greenleaf",
+    "teamSeasonName": "Greenleaf-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e7",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 ICS/TCN 3rd Grade",
+    "teamSeasonName": "ICS/TCN 4th Grade-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e8",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 ICS/TCN 3rd Grade",
+    "teamSeasonName": "ICS/TCN 4th Grade-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9e9",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 ICS/TCN 3rd Grade",
+    "teamSeasonName": "ICS/TCN 5th grade-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ea",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 ICS/TCN 3rd Grade",
+    "teamSeasonName": "ICS/TCN 5th grade-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9eb",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Learning Without Limits 3rd Grade",
+    "teamSeasonName": "Learning Without Limits BOYS-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ec",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Learning Without Limits 3rd Grade",
+    "teamSeasonName": "Learning Without Limits BOYS-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ee",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Learning Without Limits 4th Grade",
+    "teamSeasonName": "Learning Without Limits GIRLS-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9ef",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Life Academy High School",
+    "teamSeasonName": "Life Academy High School-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f0",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Life Academy High School",
+    "teamSeasonName": "Life Academy High School-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f1",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Life Academy Middle School",
+    "teamSeasonName": "Life Academy Middle School-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f2",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Life Academy Middle School",
+    "teamSeasonName": "Life Academy Middle School-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f3",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Manzanita Community",
+    "teamSeasonName": "Manzanita Community-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f6",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Oakland Academy of Knowledge",
+    "teamSeasonName": "Oakland Academy of Knowledge-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f7",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Sankofa",
+    "teamSeasonName": "Sankofa United Select-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f8",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Sankofa",
+    "teamSeasonName": "Sankofa United Juniors-2022 Spring"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f9",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Sankofa",
+    "teamSeasonName": "Sankofa United Juniors-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9fa",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Sankofa",
+    "teamSeasonName": "Sankofa United Select-2021 Fall"
+  },
+  {
+    "_id": "6248a534c90d5e4d20d1b9f5",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Manzanita SEED",
+    "teamSeasonName": "Manzanita SEED-2022 Spring"
+  },
+  {
+    "_id": "6256ceb34e32a04bdb33927d",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Global Family",
+    "teamSeasonName": "Global Family Girls-2022 Spring"
+  },
+  {
+    "_id": "6256ced74e32a04bdb33927f",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Global Family",
+    "teamSeasonName": "Global Family Girls-2021 Fall"
+  },
+  {
+    "_id": "6256d3224e32a04bdb339281",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Learning Without Limits 4th Grade",
+    "teamSeasonName": "Learning Without Limits GIRLS-2022 Spring"
+  },
+  {
+    "_id": "6256e3a14e32a04bdb339285",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 EnCompass 4th Grade",
+    "teamSeasonName": "EnCompass COED2-2021 Fall"
+  },
+  {
+    "_id": "6258dc8098d61695362c5e56",
+    "district": "district_2",
+    "districtSystemTeamName": "2021-2022 Manzanita Community",
+    "teamSeasonName": "Manzanita Community-2022 Spring"
+     }
   ]);
 }


### PR DESCRIPTION
updated for missed mappings... @chris-ebert or @matthewjerome there's so much room for human error in this list it seems like we've never quite been able to reach 100%, mainly due to human factors.

Maybe there's a way to check this file directly from Github to Mule API.
It's easy enough to define a SOQL query that returns a list of active teams by district to compare here and answer the question: "Have all the active teams in district_x been included in this file?"